### PR TITLE
Update Download location

### DIFF
--- a/YNAB4_LinuxInstall.pl
+++ b/YNAB4_LinuxInstall.pl
@@ -172,7 +172,7 @@ if ($INSTALL_MODE eq 'DOWNLOAD') {
         mydie "It looks like you don't have anything installed
                that we can use to download the latest version of YNAB4.
                Please download the Windows installer from here:\n\n
-               https://www.youneedabudget.com/download\n\n
+               https://www-assets.youneedabudget.com/ynab4/\n\n
                and then try running this script with Option 1.\n";
       }
     }


### PR DESCRIPTION
This PR currently just changes the help message about where to download - the previous link gets redirected to the main YNAB page, not the YNAB 4 download page.

I wasn't sure how to change the automatic download, which doesn't currently work. It looks like it's designed to download a YAML file that contains download URLs for different versions, and then sets `DOWNLOAD_LOCATION` from that file, but since there's no more development of YNAB4 happening, I don't think that's necessary any more. But I don't know how to fix it because I don't know perl. But the correct download location for the `.exe` file is now https://www-assets.youneedabudget.com/ynab4/YNAB+4_4.3.857_Setup.exe