### PR TITLE
Fix dropbox hack

### DIFF
--- a/YNAB4_LinuxInstall.pl
+++ b/YNAB4_LinuxInstall.pl
@@ -269,7 +269,7 @@ my $input = <STDIN>;
 chomp $input;
 $WINEDIR = $input if $input !~ /^\s*$/;
 my $WINE_DRIVEC_DIR = "$WINEDIR/drive_c";
-my $WINE_APPDATA_DIR = "$WINE_DRIVEC_DIR/users/$ENV{USER}/Application\ Data";
+my $WINE_APPDATA_DIR = "$WINE_DRIVEC_DIR/users/$ENV{USER}/AppData/Roaming";
 
 if ($INSTALL_MODE eq 'YNAB' || $INSTALL_MODE eq 'DOWNLOAD') {
   # Create the winedir, unless it already exists


### PR DESCRIPTION
YNAB seems to be looking in a different directory for the dropbox stuff.
Probably related to the change of names from Windows XP -> 7 (see e.g.
https://social.technet.microsoft.com/wiki/contents/articles/6083.windows-xp-folders-and-locations-vs-windows-7-and-vista.aspx)